### PR TITLE
The ${foo/%from} is an alternative long removal

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -187,7 +187,9 @@ dir=${src%$base}  #=> "/path/to/" (dirpath)
 | `${foo#prefix}`   | Remove prefix       |
 | ---               | ---                 |
 | `${foo%%suffix}`  | Remove long suffix  |
+| `${foo/%suffix}`  | Remove long suffix  |
 | `${foo##prefix}`  | Remove long prefix  |
+| `${foo/#prefix}`  | Remove long prefix  |
 | ---               | ---                 |
 | `${foo/from/to}`  | Replace first match |
 | `${foo//from/to}` | Replace all         |


### PR DESCRIPTION
The ${foo/%from} is an alternative form of the long suffix removal.
Likewise, he ${foo/#from} is an alternative form of the long prefix removal.

Test cases:

~~~bash
###
# Long prefix removal
###
foo=gododa

# The following are the same
r=${foo/#g*d}
r=${foo##g*d}
# Result: r=a

# (Compare to short prefix removal)
r=${foo#g*d}
# Result: r=oda

###
# Long suffix removal
###
foo=agogod

# The following are the same
r=${foo/%g*d}
r=${foo%%g*d}
# Result: r=a

# (Compare to short suffix removal)
r=${foo%g*d}
# Result: r=ago
~~~